### PR TITLE
Update Contacts strings

### DIFF
--- a/German/main/Contacts.apk/res/values-de/strings.xml
+++ b/German/main/Contacts.apk/res/values-de/strings.xml
@@ -23,7 +23,7 @@
   <string name="add_contact_dlg_message_fmt">\"%s\" zu den Kontakten hinzufügen?</string>
   <string name="add_display_photo_entry">Profilfoto hinzufügen</string>
   <string name="add_field">Weiteres Feld hinzufügen</string>
-  <string name="add_field_toast">Keine weiteren Felder zum hinzufügen</string>
+  <string name="add_field_toast">Keine weiteren Felder zum Hinzufügen</string>
   <string name="add_incall_show_entry">Video hinzufügen</string>
   <string name="add_new_account">Neues Konto hinzufügen</string>
   <string name="add_new_entry_for_section">Hinzufügen</string>
@@ -47,13 +47,13 @@
   <string name="batch_delete">Mehrere löschen</string>
   <string name="blacklist">Blockieren</string>
   <string name="bluetooth_connection_failed_toast">Bluetoothverbindung wurde unterbrochen</string>
-  <string name="blurbJoinContactDataWith">Wählen Sie den Kontakt aus, den Sie mit %s zusammenführen möchten.</string>
+  <string name="blurbJoinContactDataWith">Wählen Sie den Kontakt aus, den Sie mit %s zusammenführen möchten</string>
   <string name="btn_rotation">Drehen</string>
   <string name="btn_split_contact">Separater Kontakt</string>
   <string name="button_cancel_scan">Abbrechen</string>
   <string name="button_join_service_number">Servicenummer hinzufügen</string>
   <string name="button_my_center">Profil</string>
-  <string name="button_scan">Erneut Suchen</string>
+  <string name="button_scan">Erneut suchen</string>
   <string name="caching_vcard_message">vCard(s) zwischenspeichern…</string>
   <string name="caching_vcard_title">Zwischenspeichern</string>
   <string name="callAgain">Erneut anrufen</string>
@@ -89,7 +89,7 @@
   <string name="call_radio">Anruf (Funk)</string>
   <string name="call_record_setting_miui">Aufnahmeeinstellungen</string>
   <string name="call_settings">Einstellungen</string>
-  <string name="call_settings_primary_user_only">Anrufeinstellungen können nur vom primären Benutzer geändert werden.</string>
+  <string name="call_settings_primary_user_only">Anrufeinstellungen können nur vom primären Benutzer geändert werden</string>
   <string name="call_sim1_description">SIM 1</string>
   <string name="call_sim1_menu_title">Mit SIM 1 anrufen</string>
   <string name="call_sim2_description">SIM 2</string>
@@ -99,8 +99,8 @@
   <string name="call_tty_tdd">TTY/TDD anrufen</string>
   <string name="call_unit">USD</string>
   <string name="call_work">Anruf (geschäftl.)</string>
-  <string name="call_work_mobile">Anruf Mobiltelefon (geschäftlich)</string>
-  <string name="call_work_pager">Anruf Pager (geschäftlich)</string>
+  <string name="call_work_mobile">Anruf Mobiltelefon (geschäftl.)</string>
+  <string name="call_work_pager">Anruf Pager (geschäftl.)</string>
   <string name="calllog_menu_blacklist">Blockieren</string>
   <string name="calllog_menu_edit_before_call">Bearbeiten</string>
   <string name="calllog_menu_send_sms">SMS senden</string>
@@ -121,14 +121,14 @@
   <string name="callrecordview_menu_delete_accepted">Angenommene Anrufe löschen</string>
   <string name="callrecordview_menu_delete_all">Anrufliste löschen</string>
   <string name="callrecordview_menu_delete_called">Ausgehende Anrufe löschen</string>
-  <string name="callrecordview_menu_delete_confirm">%s Löschen?</string>
+  <string name="callrecordview_menu_delete_confirm">%s löschen?</string>
   <string name="callrecordview_menu_delete_missed">Verpasste Anrufe löschen</string>
   <string name="callrecordview_menu_delete_new">Anrufliste von neuen Kontakten löschen</string>
   <string name="callrecordview_menu_delete_one">Aus Anrufliste entfernen</string>
   <string name="callrecordview_menu_delete_sim">%s Anrufliste löschen</string>
   <string name="callrecordview_menu_delete_stranger">Unbekannte Anrufe löschen</string>
   <string name="callrecordview_menu_edit_call_note">Anrufnotiz ändern</string>
-  <string name="callrecordview_menu_ip">Autom. IP-Wählen</string>
+  <string name="callrecordview_menu_ip">Autom. IP wählen</string>
   <string name="callrecordview_menu_livetalk">Aufladepaket</string>
   <string name="callrecordview_menu_misim">Mi SIM</string>
   <string name="callrecordview_menu_mobiledata">Datenpaket kaufen</string>
@@ -164,7 +164,7 @@
   <string name="clearCallLogConfirmation">Alle Anruflisten werden gelöscht</string>
   <string name="clearCallLogConfirmation_title">Alle Anruflisten löschen?</string>
   <string name="clearCallLogProgress_title">Anrufliste wird gelöscht…</string>
-  <string name="clearFrequentsConfirmation">Wenn Sie die Liste der häufig kontaktieren Personen in den Kontakten und auf dem Telefon löschen, müssen Ihre E-Mailapps Ihre bevorzugten Adressen von Grund auf neu erlernen</string>
+  <string name="clearFrequentsConfirmation">Wenn Sie die Liste der häufig kontaktierten Personen in den Kontakten und auf dem Telefon löschen, müssen Ihre E-Mailapps Ihre bevorzugten Adressen von Grund auf neu erlernen</string>
   <string name="clearFrequentsConfirmation_title">Häufig kontaktierte Personen löschen?</string>
   <string name="clearFrequentsProgress_title">Liste der häufig kontaktierten Personen wird gelöscht…</string>
   <string name="clear_copy_number_description">Kopierte Nummer löschen</string>
@@ -212,10 +212,8 @@
   <string name="contact_detail_miprofile_accept_fail_toast">Kontaktkarte konnte nicht abgerufen werden</string>
   <string name="contact_detail_miprofile_accept_success_toast">Kontaktkarten ausgetauscht</string>
   <string name="contact_detail_miprofile_binded_label">Hinzugefügt</string>
-  <string name="contact_detail_miprofile_exchange_closed">
-    "Es ist keine Telefonnummer mit diesem Mi Konto verknüpft.
-    Kontaktkarten sind ausgeschaltet."
-  </string>
+  <string name="contact_detail_miprofile_exchange_closed">"Es ist keine Telefonnummer mit diesem Mi Konto verknüpft.
+Kontaktkarten sind ausgeschaltet."</string>
   <string name="contact_detail_miprofile_privacy_settings">Zum Anzeigen ist eine Berechtigung erforderlich</string>
   <string name="contact_detail_miprofile_request">Kontaktkarten austauschen</string>
   <string name="contact_detail_miprofile_request_fail_toast">Anfrage konnte nicht gesendet werden</string>
@@ -227,13 +225,13 @@
   <string name="contact_detail_miprofile_settings_header">WEITERE EINSTELLUNGEN</string>
   <string name="contact_detail_miprofile_subtitle">Karten bereits ausgetauscht</string>
   <string name="contact_detail_profile_switch_fail_network_toast">Netzwerkverbindung fehlgeschlagen</string>
-  <string name="contact_detail_profile_switch_fail_toast">Es ist ein Fehler mit unseren Server aufgetreten</string>
+  <string name="contact_detail_profile_switch_fail_toast">Es ist ein Fehler mit unserem Server aufgetreten</string>
   <string name="contact_detail_profile_switch_off">Kontaktkarten sind aus</string>
   <string name="contact_detail_profile_switch_off_fail_toast">Kontaktkarten konnten nicht ausgeschaltet werden</string>
   <string name="contact_detail_profile_switch_off_success_toast">Kontaktkarten sind aus</string>
   <string name="contact_detail_profile_switch_on">Profilfotos anzeigen</string>
   <string name="contact_detail_profile_switch_on_fail_toast">Kontaktkarten konnten eingeschaltet werden</string>
-  <string name="contact_detail_profile_switch_on_subtitle">Tippen um Kontaktkarten zu aktivieren</string>
+  <string name="contact_detail_profile_switch_on_subtitle">Tippen, um Kontaktkarten zu aktivieren</string>
   <string name="contact_detail_profile_switch_on_success_toast">Kontaktkarten sind bereits eingeschaltet</string>
   <string name="contact_directory_description">Verzeichnis %1$s</string>
   <string name="contact_edit_save_error_empty">Kontakt ist leer</string>
@@ -243,7 +241,7 @@
   <string name="contact_editor_prompt_multiple_accounts">Kontakt speichern unter</string>
   <string name="contact_editor_prompt_one_account">Neuer Kontakt wird mit %1$s synchronisiert</string>
   <string name="contact_editor_prompt_zero_accounts">Im Telefon speichern oder ein neues Konto anlegen</string>
-  <string name="contact_is_readOnly">Nur lesbare Kontakte können nicht geändert werden</string>
+  <string name="contact_is_readOnly">Nur-lesen Kontakte können nicht geändert werden</string>
   <string name="contact_list_loading">Lade…</string>
   <string name="contact_pick_photo">Bild</string>
   <string name="contact_read_only">Mit dieser App nicht bearbeitbar</string>
@@ -264,7 +262,7 @@
   <string name="convenient_service">Dienste</string>
   <string name="copy_number">Kopieren</string>
   <string name="copy_text">In Zwischenablage kopieren</string>
-  <string name="createContactShortcutSuccessful">Kontaktverknüpfung zum Desktop hinzugefügt</string>
+  <string name="createContactShortcutSuccessful">Kontaktverknüpfung zum Startbildschirm hinzugefügt</string>
   <string name="create_group_dialog_title">Neue Gruppe erstellen</string>
   <string name="create_group_item_label">Neue Gruppe erstellen</string>
   <string name="create_qrcode_fail_message">Erstellung des QR-Code fehlgeschlagen</string>
@@ -278,7 +276,7 @@
   <string name="data_unit_mb">MB</string>
   <string name="date_time_set">Speichern</string>
   <string name="date_year_toggle">Jahr angeben</string>
-  <string name="default_ringtone">Standard Klingelton</string>
+  <string name="default_ringtone">Standardklingelton</string>
   <string name="deleteConfirmation">Dieser Kontakt wird gelöscht</string>
   <string name="deleteConfirmationDetail">\"%s\" löschen?</string>
   <string name="deleteConfirmation_title">Diesen Kontakt löschen?</string>
@@ -344,10 +342,8 @@
   <string name="details_list_group_header_other">WEITERE</string>
   <string name="device_bluetooth_title">Kontakte übertragen</string>
   <string name="device_import_account_dialog_title">Konto auswählen</string>
-  <string name="device_import_account_dialog_title_suffix">
-    "
-    (%1$s Kontakte gefunden)"
-  </string>
+  <string name="device_import_account_dialog_title_suffix">"
+(%1$s Kontakte gefunden)"</string>
   <string name="device_import_failed_message">Import fehlgeschlagen</string>
   <string name="device_import_local_account">Lokales Konto</string>
   <string name="device_import_message">Importiere</string>
@@ -363,25 +359,17 @@
   <string name="device_paired_dialog_title">Kontakte abrufen…</string>
   <string name="device_pairing_dialog_message">Verbinden…</string>
   <string name="device_pairing_dialog_title">Geräte verbinden</string>
-  <string name="device_transfer_by_bluetooth_message">
-    "1. Bitte schalten Sie "Bluetooth" auf dem anderen Gerät ein;
+  <string name="device_transfer_by_bluetooth_message">"1. Bitte schalten Sie "Bluetooth" auf dem anderen Gerät ein;
 
+- Auf Androidgeräten finden Sie "Bluetooth" normalerweise bei den Netzwerkeinstellungen
+- Auf iOS-Geräten sollten Sie "Bluetooth" in den Einstellungen suchen
 
-    - Auf Androidgeräten finden Sie "Bluetooth" normalerweise bei den Netzwerkeinstellungen
+2. Auf Androidgeräten sollten Sie außerdem die "Sichtbarkeit für andere Geräte" einschalten;
 
-    - Auf iOS-Geräten sollten Sie "Bluetooth" in den Einstellungen suchen
+3. Klicken Sie "Weiter"und erlauben Sie im nächsten Schritt den Zugriff auf die Kontakte."</string>
+  <string name="device_transfer_by_sim_message">"1. Speichern Sie die Kontakte des anderen Geräts auf der SIM-Karte;
 
-
-    2. Auf Androidgeräten sollten Sie außerdem die "Sichtbarkeit für andere Geräte" einschalten;
-
-
-    3. Klicken Sie "Weiter"und erlauben Sie im nächsten Schritt den Zugriff auf die Kontakte."
-  </string>
-  <string name="device_transfer_by_sim_message">
-    "1. Speichern Sie die Kontakte des anderen Geräts auf der SIM-karte;
-
-
-    2. Gehen Sie zu "Kontakteinstellungen" -- "Kontakte importieren/exportieren" -- "Von SIM-Karte importieren", halten Sie einen Kontakt gedrückt, wählen Sie die zu importierenden Kontakte aus, dann klicken Sie "Importieren"."
+2. Gehen Sie zu "Kontakteinstellungen" -- "Kontakte importieren/exportieren" -- "Von SIM-Karte importieren", halten Sie einen Kontakt gedrückt, wählen Sie die zu importierenden Kontakte aus, dann klicken Sie "Importieren"."
   </string>
   <string name="device_version_header_bluetooth">Stellen Sie sicher, dass Bluetooth an ist</string>
   <string name="device_version_header_no_bluetooth">Kontakte von SIM-Karte importieren</string>
@@ -395,7 +383,7 @@
   <string name="dialer_empty_text_loading">Einen Moment…</string>
   <string name="dialer_empty_text_no_call_log">Keine Anrufe</string>
   <string name="dialer_empty_text_no_search_result">Keine Kontakte gefunden</string>
-  <string name="dialer_menu_description">Antippen, um das Wählmenü zu öffnen</string>
+  <string name="dialer_menu_description">Tippen, um das Wählmenü zu öffnen</string>
   <string name="dialer_menu_title">Optionen</string>
   <string name="dialer_returnToInCallScreen">Zurück zum aktuellen Gespräch</string>
   <string name="dialer_useDtmfDialpad">Tonwahltastatur verwenden</string>
@@ -406,12 +394,10 @@
   <string name="dialog_phone_call_prohibited_message">Anrufe sind nicht erlaubt</string>
   <string name="dialog_sync_add">Synchronisationsgruppe hinzufügen</string>
   <string name="dialog_voicemail_airplane_mode_message">Um die Mailbox abzurufen, schalten Sie den Flugmodus aus</string>
-  <string name="dialog_voicemail_not_ready_message">Zum Einrichten der Mailbox gehen Sie in das Menü > Einstellungen</string>
+  <string name="dialog_voicemail_not_ready_message">Zum Einrichten der Mailbox gehen Sie ins Menü &gt; Einstellungen</string>
   <string name="directory_search_label">Verzeichnis</string>
-  <string name="disclaimer_text">
-    "Gelbe Seiten bekommen Informationen über Ihr Guthaben per SMS. Ihr Mobilfunkbetreiber kann diese Informationen mit einer Verzögerung aktualisieren, so dass die Zahlen, die Sie erhalten, möglicherweise nicht korrekt sind. Die Fehler können Sie per SMS melden, um  dieses Service zu verbessern.
-    Die Guthabeninformationen werden einmal täglich aktualisiert, um die Anzahl der Abfragen zu reduzieren."
-  </string>
+  <string name="disclaimer_text">"Gelbe Seiten bekommen Informationen über Ihr Guthaben per SMS. Ihr Mobilfunkbetreiber kann diese Informationen mit einer Verzögerung aktualisieren, so dass die Zahlen, die Sie erhalten, möglicherweise nicht korrekt sind. Die Fehler können Sie per SMS melden, um  diesen Service zu verbessern.
+Die Guthabeninformationen werden einmal täglich aktualisiert, um die Anzahl der Abfragen zu reduzieren."</string>
   <string name="disclaimer_title">Disclaimer</string>
   <string name="display_all_contacts">Alle Kontakte</string>
   <string name="display_more_groups">Weitere Gruppen…</string>
@@ -458,10 +444,8 @@
   <string name="export_to_sim_prepare_title">Wird vorbereitet…</string>
   <string name="export_to_sim_title">Exportiere…</string>
   <string name="export_vcard_description">"vCard in USB-Speicher exportieren"</string>
-  <string name="exporting_contact_failed_message">
-    "Die Kontaktdaten wurden nicht exportiert.
-    Grund: \"%s\"."
-  </string>
+  <string name="exporting_contact_failed_message">"Die Kontaktdaten wurden nicht exportiert.
+Grund: \"%s\""</string>
   <string name="exporting_contact_failed_title">Export nicht möglich</string>
   <string name="exporting_contact_list_message">Ihre Kontaktdaten werden nach \"%s\" exportiert</string>
   <string name="exporting_contact_list_progress" formatted="false">%s von %s Kontakten</string>
@@ -470,7 +454,7 @@
   <string name="exporting_vcard_finished_title">Export von %s abgeschlossen</string>
   <string name="external_profile_title">Mein %1$s Mi Profil</string>
   <string name="fail_reason_could_not_initialize_exporter">Exportierer konnte nicht gestartet werden: \"%s\"</string>
-  <string name="fail_reason_could_not_open_file" formatted="false">"Konnte nicht geöffnet werden \"%s\": %s"</string>
+  <string name="fail_reason_could_not_open_file" formatted="false">Konnte nicht geöffnet werden \"%s\": %s</string>
   <string name="fail_reason_error_occurred_during_export">Fehler beim Exportieren: \"%s\"</string>
   <string name="fail_reason_failed_to_collect_vcard_meta_info">Die Meta-Informationen der vCard Datei(en) konnten nicht gelesen werden</string>
   <string name="fail_reason_failed_to_read_files">Eine oder mehrere Dateien konnten nicht importiert werden (%s)</string>
@@ -493,7 +477,7 @@
   <string name="frequentList">Häufig</string>
   <string name="full_name">Name</string>
   <string name="gallery">Galerie</string>
-  <string name="generic_no_account_prompt">Schützen Sie Ihre Kontakte bei Verlust des Telefons: Synchronisieren Sie Ihre Kontakte mit einem Onlinedienst.</string>
+  <string name="generic_no_account_prompt">Schützen Sie Ihre Kontakte bei Verlust des Telefons: Synchronisieren Sie Ihre Kontakte mit einem Onlinedienst</string>
   <string name="generic_no_account_prompt_title">Konto hinzufügen</string>
   <string name="ghostData_company">Firma</string>
   <string name="ghostData_title">Titel</string>
@@ -609,11 +593,11 @@
   <string name="local_search_label">Alle Kontakte</string>
   <string name="locale_change_in_progress">Kontaktliste wird an die geänderte Sprache angepasst</string>
   <string name="login_ok">Anmelden</string>
-  <string name="low_memory_toast">Nicht genügend Speicherplatz.</string>
+  <string name="low_memory_toast">Nicht genug Speicherplatz</string>
   <string name="lunarBirthdayLabelsGroup">Geburtstag</string>
   <string name="lunar_calendar">Mondkalender</string>
-  <string name="lunar_leap">Einschiebung</string>
-  <string name="lunar_yue">Lunation</string>
+  <string name="lunar_leap">Schaltmonat</string>
+  <string name="lunar_yue">Monat</string>
   <string name="make_primary">Diese Auswahl speichern</string>
   <string name="map_custom">%s Adresse anzeigen</string>
   <string name="map_home">Privatadresse anzeigen</string>
@@ -685,7 +669,7 @@
   <string name="miprofile_bind_account_alertdialog_title">Telefonnummer hinzufügen</string>
   <string name="miprofile_contact_add">Hinzufügen</string>
   <string name="miprofile_contact_added">Hinzugefügt</string>
-  <string name="miprofile_contact_header">Kontkte mit Kontaktkarten</string>
+  <string name="miprofile_contact_header">Kontakte mit Kontaktkarten</string>
   <string name="miprofile_contact_meaasge">Lokale Kontakte</string>
   <string name="miprofile_contact_verifying">Wird überprüft</string>
   <string name="miprofile_edit_title">Profil bearbeiten</string>
@@ -697,7 +681,7 @@
   <string name="miprofile_find_miprofile_title">Profil hinzufügen</string>
   <string name="miprofile_find_profile_batch_add">Alle Profil hinzufügen</string>
   <string name="miprofile_find_profile_batch_finish">Fertig</string>
-  <string name="miprofile_find_profile_batch_request_failed">Fehler beim Hinzufügen von Profil</string>
+  <string name="miprofile_find_profile_batch_request_failed">Fehler beim Hinzufügen des Profils</string>
   <string name="miprofile_find_profile_loading">Laden</string>
   <string name="miprofile_find_profile_no_recommend">Kein Profil empfehlen</string>
   <string name="miprofile_finding_label">Hier finden Sie Kontaktkarten</string>
@@ -727,15 +711,15 @@
   <string name="miprofile_request_notification_title_name">%1$s möchte die Kontaktkarten austauschen</string>
   <string name="miprofile_save_alertdialog_message">Ihre Karte wird automatisch an diesen Kontakt versendet</string>
   <string name="miprofile_save_alertdialog_title">Kontaktkarte empfangen</string>
-  <string name="miprofile_switch_off_alertdialog_message">Sie werden keine Kontaktkarten mit anderen Personen austauschen können.</string>
+  <string name="miprofile_switch_off_alertdialog_message">Sie werden keine Kontaktkarten mit anderen Personen austauschen können</string>
   <string name="miprofile_switch_on_alertdialog_message">Tauschen Sie die Kontaktkarten aus, um das aktualisierte Profilfoto anzuzeigen</string>
   <string name="miprofile_switch_on_alertdialog_positive">Einschalten</string>
   <string name="miprofile_switch_on_alertdialog_title">Profilfotoupdate</string>
   <string name="missing_name">(Kein Name)</string>
-  <string name="missing_required_permission">Sie haben eine notwendige Berechtigung nicht erteilt.</string>
+  <string name="missing_required_permission">Sie haben eine notwendige Berechtigung nicht erteilt</string>
   <string name="mobile_equipment_identification">Mobilgeräteidentifikation</string>
   <string name="more_call_logs">Detaillierte Anrufliste anzeigen auf i.mi.com</string>
-  <string name="move_and_resize">Verschieben und Skalieren</string>
+  <string name="move_and_resize">Verschieben und skalieren</string>
   <string name="multi_number_menu_call">Anruf</string>
   <string name="multi_number_menu_delete">Löschen</string>
   <string name="multi_number_menu_group">Neue Gruppe</string>
@@ -799,7 +783,7 @@
     </b>"
     "
   </string>
-  <string name="noContactsHelpTextForCreateShortcut">"Keine Kontakte zum Anzeigen vorhanden."</string>
+  <string name="noContactsHelpTextForCreateShortcut">Keine Kontakte zum Anzeigen vorhanden</string>
   <string name="noContactsHelpTextWithSync">
     "Keine Kontakte zum Anzeigen vorhanden. (Sollten Sie gerade ein Konto hinzugefügt haben, kann es einen Moment bis zur Anzeige dauern.)
 
@@ -841,7 +825,7 @@
     </b>"
     "
   </string>
-  <string name="noContactsHelpTextWithSyncForCreateShortcut">"Keine Kontakte zum Anzeigen vorhanden. (Sollten Sie gerade ein Konto hinzugefügt haben, kann es einen Moment bis zur Anzeige dauern.)"</string>
+  <string name="noContactsHelpTextWithSyncForCreateShortcut">Keine Kontakte zum Anzeigen vorhanden. (Sollten Sie gerade ein Konto hinzugefügt haben, kann es einen Moment bis zur Anzeige dauern.)</string>
   <string name="noContactsNoSimHelpText">
     "Keine Kontakte zum Anzeigen vorhanden.
 
@@ -939,11 +923,10 @@
   <string name="noGroups">Keine Gruppen</string>
   <string name="noMatchingContacts">Keine passenden Kontakte gefunden</string>
   <string name="noRecentContacts">Keine aktuellen Kontakte</string>
-  <string name="no_account_prompt">
-    "Die Kontakteapp funktioniert am besten mit einem Google-Konto.
+  <string name="no_account_prompt">"Die Kontakteapp funktioniert am besten mit einem Google-Konto.
 
-    • Zugriff über einen beliebigen Browser.
-    • Sichern ihrer Kontakte."
+    • Zugriff über einen beliebigen Browser
+    • Sichern Ihrer Kontakte"
   </string>
   <string name="no_contact_details">Keine Zusatzinformationen zu diesem Kontakt</string>
   <string name="no_contact_in_other_phone">Keine Kontakte gefunden</string>
@@ -954,7 +937,7 @@
   <string name="non_phone_add_to_contacts">Zu einem existierenden Kontakt hinzufügen</string>
   <string name="non_phone_caption">Telefonnummer</string>
   <string name="non_phone_close">Schließen</string>
-  <string name="none_paired">Zurzeit sind keine Geräte verbunden.</string>
+  <string name="none_paired">Zurzeit sind keine Geräte verbunden</string>
   <string name="not_applied">Nicht angewendet</string>
   <string name="notification_action_voicemail_play">Abspielen</string>
   <string name="notification_new_voicemail_ticker">Neue Sprachnachricht von %1$s</string>
@@ -1011,8 +994,8 @@
   <string name="photoPickerNotFoundText">Auf dem Telefon sind keine Bilder verfügbar</string>
   <string name="photo_fragment">Foto</string>
   <string name="photo_load_failed">Foto konnte nicht geladen werden</string>
-  <string name="pick_new_photo">Neues Bild aus der %s auswählen</string>
-  <string name="pick_photo">Bild aus der %s auswählen</string>
+  <string name="pick_new_photo">Neues Foto aus der %s auswählen</string>
+  <string name="pick_photo">Foto aus der %s auswählen</string>
   <string name="pickerNewContactHeader">Neuen Kontakt erstellen</string>
   <string name="pickerNewContactText">Neuen Kontakt erstellen</string>
   <string name="picker_all_list_empty">Keine Kontakte</string>
@@ -1036,7 +1019,7 @@
   <string name="postal_postcode">Postleitzahl</string>
   <string name="postal_region">Bundesland/Kanton</string>
   <string name="postal_street">Straße</string>
-  <string name="pref_key_photo">Bild</string>
+  <string name="pref_key_photo">Foto</string>
   <string name="pref_key_photo_word_summary">Automatische Zuweisung eines Fotos zu Kontakten ohne ein Foto</string>
   <string name="pref_key_photo_word_title">Kontaktfotozuweisung</string>
   <string name="pref_key_rebuild_t9_index_message">Behebt Fehler bei der Kontaktsuche</string>
@@ -1044,7 +1027,7 @@
   <string name="pref_key_sim_manage">SIM-Karte verwalten</string>
   <string name="pref_key_sim_manage1">SIM-Karte 1 verwalten</string>
   <string name="pref_key_sim_manage2">SIM-Karte 2 verwalten</string>
-  <string name="pref_summary_import_from_account">Importiert Kontakte aus Google und Exchange-Konten in Ihr Mi Konto</string>
+  <string name="pref_summary_import_from_account">Importiert Kontakte aus Google- und Exchange-Konten in Ihr Mi Konto</string>
   <string name="pref_title_account_import">Aus Konto importieren</string>
   <string name="pref_title_import_from_account">In Mi Konto importieren</string>
   <string name="preference_auto_ip_summary_disable">Ausgeschaltet</string>
@@ -1064,14 +1047,14 @@
   <string name="preference_export">Exportieren</string>
   <string name="preference_import">Importieren</string>
   <string name="preference_import_export">Import/Export</string>
-  <string name="preference_import_export_title">Kontakte Importieren/Exportieren</string>
+  <string name="preference_import_export_title">Kontakte importieren/exportieren</string>
   <string name="preference_key_trash_bin_title">Gesicherte Kontakte nach kürzlich gelöschten durchsuchen</string>
   <string name="preference_other">Andere</string>
   <string name="preference_others">Andere</string>
   <string name="preference_phone">Telefon</string>
   <string name="preference_phone_more_title">Anrufeinstellungen</string>
   <string name="preference_remove_duplicate">Identische Kontakte zusammenführen</string>
-  <string name="preference_show_yellowpage_tab_description">Gelbe Seiten funktionieren möglicherweise nicht richtig, wenn diese Funktion deaktiviert ist.</string>
+  <string name="preference_show_yellowpage_tab_description">Gelbe Seiten funktionieren möglicherweise nicht richtig, wenn diese Funktion deaktiviert ist</string>
   <string name="preference_show_yellowpage_tab_title">Gelbe Seiten anzeigen</string>
   <string name="preference_simple_mode_description">Kontaktbilder und andere Kontaktdaten anzeigen</string>
   <string name="preference_simple_mode_title">Bilder und Kontaktdaten</string>
@@ -1083,7 +1066,7 @@
   <string name="preference_smart_group_location_title">Nach Vorwahl</string>
   <string name="preference_smart_group_title">Intelligentes Sortieren</string>
   <string name="preference_telocation_summary_countrycode_off">Ländervorwahl nicht hinzufügen</string>
-  <string name="preference_telocation_summary_countrycode_on">Autoländervorwahl hinzufügen</string>
+  <string name="preference_telocation_summary_countrycode_on">Auto-Ländervorwahl hinzufügen</string>
   <string name="preference_telocation_summary_teloc_off">Standort ausblenden</string>
   <string name="preference_telocation_summary_teloc_on">Standort einblenden</string>
   <string name="preference_telocation_title">Standort</string>
@@ -1093,7 +1076,7 @@
   <string name="preview_incall_show_entry">Videovorschau</string>
   <string name="previous">Zurück</string>
   <string name="private_num">Private Nummer</string>
-  <string name="profileSavedErrorToast">"Meine Profiländerungen konnten nicht gespeichert werden"</string>
+  <string name="profileSavedErrorToast">Meine Profiländerungen konnten nicht gespeichert werden</string>
   <string name="profileSavedToast">Profile gespeichert</string>
   <string name="profile_binded_numbers">%s</string>
   <string name="profile_delete_toast">Profil erfolgreich gelöscht</string>
@@ -1105,7 +1088,7 @@
   <string name="pull_to_refresh_release_label">Zum Aktualisieren loslassen…</string>
   <string name="qr_card_card">Mein QR-Code</string>
   <string name="qrcode_card_title">QR-Code Karte</string>
-  <string name="qrcode_editor_flash_failed">"QR-Code konnte nicht aktualisiert"</string>
+  <string name="qrcode_editor_flash_failed">QR-Code konnte nicht aktualisiert</string>
   <string name="quickcontact_missing_app">Für diese Aktion wurde keine Anwendung gefunden</string>
   <string name="quit_dialog_confirm_message">Sie haben noch keine Kontakte zusammengeführt</string>
   <string name="quit_dialog_confirm_title">Sie haben noch keine Kontakte zusammengeführt</string>
@@ -1129,7 +1112,7 @@
   <string name="recent_contacts_label">Aktuellste</string>
   <string name="recent_number">Aktuell</string>
   <string name="recent_updates">Kürzliche Updates</string>
-  <string name="redirect_calls_to_vm_confirm_message">Vor dem Einrichten Ihrer Mailbox, überprüfen Sie die Vertragsbedingungen von Ihrem Mobilfunkanbieter.</string>
+  <string name="redirect_calls_to_vm_confirm_message">Vor dem Einrichten Ihrer Mailbox prüfen Sie die Vertragsbedingungen Ihres Mobilfunkanbieters.</string>
   <string name="redirect_calls_to_vm_confirm_text">OK</string>
   <string name="refresh">Aktualisieren</string>
   <string name="relationLabelsGroup">Beziehung</string>
@@ -1137,10 +1120,9 @@
   <string name="remove_blacklist">Nicht blockieren</string>
   <string name="remove_blacklist_dialog_message">Diese Nummer entsperren?</string>
   <string name="remove_blacklist_dialog_title">Entsperren</string>
-  <string name="remove_duplicate">
-    "MIUI hilft Ihnen identische Kontakte zu finden.
+  <string name="remove_duplicate">"MIUI hilft Ihnen identische Kontakte zu finden.
 
-    Drücken Sie auf Zusammenführen, um zu beginnen."
+Drücken Sie auf Zusammenführen, um zu beginnen."
   </string>
   <string name="report_inquiry_mms">Bericht-SMS</string>
   <string name="restore_nickname">Wiederherstellen</string>
@@ -1157,7 +1139,7 @@
   <string name="scan_duplicate_message">%1$d Kontakte mit identischen Daten</string>
   <string name="scan_merge">Suche nach identischen Kontakten…</string>
   <string name="scan_qrcode_card_hint1">QR-Code scannen</string>
-  <string name="scan_qrcode_card_hint2">Meine Informationen, zu Ihren Kontakten hinzufügen</string>
+  <string name="scan_qrcode_card_hint2">Meine Informationen zu Ihren Kontakten hinzufügen</string>
   <string name="scanning_sdcard_failed_message">Grund: \"%s\"</string>
   <string name="scanning_sdcard_failed_title">Die SD-Karte konnte nicht durchsucht werden</string>
   <string name="searchHint">Kontakte durchsuchen</string>
@@ -1189,7 +1171,7 @@
   <string name="search_wipe_data">Organisieren;Kontakte</string>
   <string name="searching_vcard_message">Suche nach vCard-Daten im USB-Speicher…</string>
   <string name="select_all">Alle</string>
-  <string name="select_all_exceed">"Wähle nicht mehr als %1$d aus. Es können nicht alle ausgewählt werden"</string>
+  <string name="select_all_exceed">Wähle nicht mehr als %1$d aus. Es können nicht alle ausgewählt werden.</string>
   <string name="select_exceed">Wähle nicht mehr als %1$d aus</string>
   <string name="select_groups">Gruppen auswählen</string>
   <string name="select_none">Nichts ausgewählt</string>
@@ -1204,7 +1186,7 @@
   <string name="service_provider_detail">Ordnerdetails</string>
   <string name="set_data_package">Erst Datenpaket auswählen</string>
   <string name="set_default">Festlegen von Standard</string>
-  <string name="set_photo_failed_msg">Kontaktbild konnte nicht gesetzt werden</string>
+  <string name="set_photo_failed_msg">Kontaktfoto konnte nicht gesetzt werden</string>
   <string name="share_error">Kontakt kann nicht geteilt werden</string>
   <string name="share_over_limit">Mehr als 1000 Kontakte können nicht geteilt werden</string>
   <string name="share_via">Senden mittels</string>
@@ -1221,7 +1203,7 @@
   <string name="sim_account_name">SIM</string>
   <string name="sim_capacity">SIM-Kartenkapazität anzeigen</string>
   <string name="sim_capacity_content" formatted="false">%d Gesamt | %d verwendet</string>
-  <string name="sim_card_no_free_space_message">Nicht genügend Speicherplatz</string>
+  <string name="sim_card_no_free_space_message">Nicht genug Speicherplatz</string>
   <string name="sim_card_no_free_space_title">SIM-Karte ist voll</string>
   <string name="sim_contact_dropdown_menu_deselect_all_miui">Keine</string>
   <string name="sim_contact_dropdown_menu_select_all_miui">Alle</string>
@@ -1336,9 +1318,9 @@
   <string name="unknown_contact_name">Unbekannter Kontakt</string>
   <string name="unknown_details_add_to_contact">Existierend</string>
   <string name="unknown_details_new_contact">Neu</string>
-  <string name="update_sim_contact_photo_toast">"Kann für SIM-Kontakte keine Profilfotos einfügen"</string>
-  <string name="upgrade_in_progress">Kontaktliste wird aktualisiert.</string>
-  <string name="upgrade_out_of_memory">"Ihre Kontakte werden momentan aktualisiert. Für den Aktualisierungsvorgang sind ca. %s MB interner Speicher erforderlich. Wählen Sie eine der folgenden Optionen:"</string>
+  <string name="update_sim_contact_photo_toast">Kann für SIM-Kontakte keine Profilfotos einfügen</string>
+  <string name="upgrade_in_progress">Kontaktliste wird aktualisiert</string>
+  <string name="upgrade_out_of_memory">Ihre Kontakte werden momentan aktualisiert. Für den Aktualisierungsvorgang sind ca. %s MB interner Speicher erforderlich. Wählen Sie eine der folgenden Optionen:</string>
   <string name="upgrade_out_of_memory_retry">Aktualisierung wiederholen</string>
   <string name="upgrade_out_of_memory_uninstall">Deinstallieren Sie einige Apps</string>
   <string name="use_photo_as_primary">Dieses Bild verwenden</string>
@@ -1350,7 +1332,7 @@
   <string name="vcard_import_failed">Importieren der vCard %s nicht möglich</string>
   <string name="vcard_import_request_rejected_message">Die vCard-Importanfrage wurde abgelehnt. Später erneut versuchen.</string>
   <string name="vcard_import_will_start_message">%s wird in Kürze importiert</string>
-  <string name="vcard_import_will_start_message_with_default_name">Die Datei wird in Kürze importiert.</string>
+  <string name="vcard_import_will_start_message_with_default_name">Die Datei wird in Kürze importiert</string>
   <string name="vcard_unknown_filename">Kontakt</string>
   <string name="video_call">Videoanruf</string>
   <string name="video_chat">Videochat</string>
@@ -1379,10 +1361,10 @@
   <string name="wipe_data">Daten löschen</string>
   <string name="yellowPageNavigationIconLabel">Gelbe Seiten</string>
   <string name="yellowPageNavigationLabel">Gelbe Seiten</string>
-  <string name="yellowpage_fc_toast">Konnte nicht weiter verwenden, da Gelbe Seiten abstürzten.</string>
+  <string name="yellowpage_fc_toast">Kann diese Funktion nicht nutzen, weil Gelbe Seiten abgestürzt sind</string>
   <string name="yellowpage_mi_family">Mi Familie</string>
   <string name="yellowpage_navigation_ad_hint">Werbung</string>
-  <string name="yellowpage_navigation_balance_refresh_failed">Guthaben und Daten konnten nicht überprüft werden, versuchen Sie später erneut.</string>
+  <string name="yellowpage_navigation_balance_refresh_failed">Guthaben und Daten konnten nicht überprüft werden, versuchen Sie später erneut</string>
   <string name="yellowpage_navigation_balance_refresh_succeed">Guthaben und Daten wurden überprüft</string>
   <string name="yellowpage_navigation_clear_search_history">Verlauf löschen</string>
   <string name="yellowpage_navigation_more_items">Mehr</string>


### PR DESCRIPTION
Z 155 string name="chat_aim">Über AIM chatten</string: Den String kann man bald rausnehmen, AIM wird am 15.12. abgeschaltet (Kunden werden bereits informiert).
HTML-Strings ab Zeile 753 bis 922: Werden die mit den ganzen Zeilenschaltungen wirklich korrekt am Handy angezeigt?