### PR TITLE
Fixing plural of steps

### DIFF
--- a/German/main/PersonalAssistant.apk/res/values-de/plurals.xml
+++ b/German/main/PersonalAssistant.apk/res/values-de/plurals.xml
@@ -58,7 +58,7 @@
     <item quantity="other">%1$dd her</item>
   </plurals>
   <plurals name="steps">
-    <item quantity="other">%d|Schritten</item>
+    <item quantity="other">%d|Schritte</item>
     <item quantity="zero">%d|Schritte</item>
     <item quantity="one">%d|Schritt</item>
   </plurals>


### PR DESCRIPTION
Plural of Schritt should be Schritte instead of Schritten.
```
0 Schritte
1 Schritt
2312 Schritte
```